### PR TITLE
Add nbgitpuller link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ We will cover:
 * Web browser
 * Coffee (optional, but recommended)
 
+## Get Started
+
+* [Run the clinic tutorials](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2FUT_Landlab_Clinic&urlpath=tree%2FUT_Landlab_Clinic%2Fnotebooks%2Findex.ipynb&branch=master)
 
 ### Note to admins
 


### PR DESCRIPTION
This PR adds an *nbgitpuller* link to the repo README. When a user clicks on the link, they'll be taken to the CSDMS JupyterHub and prompted to login (if they haven't already). The repository is then cloned to their home directory on the JHub, and the **index.ipynb** Notebook is displayed. 

Clicking on the link again is harmless--it just updates the local repo on the JHub in case any changes have been made to the remote. 